### PR TITLE
Fix function where not all code paths return a value

### DIFF
--- a/expression2/alx_pc/hdd/wm1_fs.txt
+++ b/expression2/alx_pc/hdd/wm1_fs.txt
@@ -1305,6 +1305,8 @@ function number cmd_wm1_rawwritefile(Args:table) {
         CurTask[1,number] = Max
         return 1
     }
+
+    return 0
 }
 
 function number cmd_wm1_rawwritefile_helper(CmdData:table) {


### PR DESCRIPTION
New change in the compiler to userfunctions ensures they return something at compile time for performance. This function was missing a return in case all the if statements failed

@AlexALX 

https://github.com/wiremod/wire/issues/2841