### PR TITLE
Add gitignore for use in data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+advdupe2
+!advdupe2/alx_pc
+
+expression2
+!expression2/alx_pc


### PR DESCRIPTION
This adds a gitignore file that ignores your advdupe2/expression2 folders in case you want to clone this repository to your data folder.